### PR TITLE
Dependabot Check npm Packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,10 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
This pull request adds a configuration in the `dependabot.yml` file to enable Dependabot to check for new versions of npm packages.