### PR TITLE
Audit Nx Tasks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         run: yarn clean
 
       - name: Build dist
-        run: yarn build
+        run: yarn nx build
 
       - name: Check diff
         run: git diff --exit-code HEAD

--- a/nx.json
+++ b/nx.json
@@ -6,5 +6,22 @@
         "cacheableOperations": ["build", "format", "lint", "sort"]
       }
     }
+  },
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"]
+  },
+  "targetDefaults": {
+    "build": {
+      "inputs": ["default"],
+      "dependsOn": ["lint"]
+    },
+    "format": {
+      "inputs": ["default"],
+      "dependsOn": ["sort"]
+    },
+    "lint": {
+      "inputs": ["default"],
+      "dependsOn": ["format"]
+    }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -8,20 +8,31 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*"]
+    "dependencies": ["{projectRoot}/.pnp.*", "{projectRoot}/package.json"]
   },
   "targetDefaults": {
     "build": {
-      "inputs": ["default"],
-      "dependsOn": ["lint"]
+      "dependsOn": ["lint"],
+      "inputs": [
+        "dependencies",
+        "{projectRoot}/src/**/*.mts",
+        "{projectRoot}/tsconfig.json"
+      ]
     },
     "format": {
-      "inputs": ["default"],
-      "dependsOn": ["sort"]
+      "dependsOn": ["sort"],
+      "inputs": ["dependencies", "{projectRoot}/**/*", "{projectRoot}/**/.*"]
     },
     "lint": {
-      "inputs": ["default"],
-      "dependsOn": ["format"]
+      "dependsOn": ["format"],
+      "inputs": [
+        "dependencies",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/.eslintrc.json"
+      ]
+    },
+    "sort": {
+      "inputs": ["dependencies"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "nx exec -- tsc",
-    "clean": "nx exec -- rimraf dist",
-    "format": "nx exec -- prettier --write .",
-    "lint": "nx exec -- eslint src",
-    "sort": "nx exec -- sort-package-json",
-    "test": "nx exec -- jest"
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "format": "prettier --write .",
+    "lint": "eslint src",
+    "sort": "sort-package-json",
+    "test": "jest"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -56,37 +56,5 @@
     "typescript": "^5.1.6"
   },
   "packageManager": "yarn@3.6.1",
-  "nx": {
-    "namedInputs": {
-      "default": [
-        "{projectRoot}/**/*"
-      ]
-    },
-    "targets": {
-      "build": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "lint"
-        ]
-      },
-      "format": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "sort"
-        ]
-      },
-      "lint": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "format"
-        ]
-      }
-    }
-  }
+  "nx": {}
 }


### PR DESCRIPTION
This pull request makes the following modifications to the Nx configuration:

- Moves Nx inputs and task declarations from the `package.json` to the `nx.json`.
- Updates scripts in the `package.json` to no longer use the `nx exec` commands. Instead, it is now recommended to directly run the `nx` command (e.g., `yarn nx build`) to utilize Nx effectively.
- Adjusts the inputs of each task to ensure caching is triggered only if the appropriate files are changed.

This pull request effectively resolves #45.