### PR TITLE
Configure Dependabot Config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]
 
   - package-ecosystem: npm
     directory: /
@@ -13,3 +14,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]


### PR DESCRIPTION
This pull request configures the labels used by Dependabot to be `chore`.