### PR TITLE
Remove the `latest` Branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,8 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["*", "!latest"]
   push:
-    branches: [latest, main]
+    branches: [main]
 env:
   NODE_OPTIONS: --experimental-vm-modules
 jobs:


### PR DESCRIPTION
This pull request removed the `latest` branch by removing that branch from affecting triggers in the CI workflow. It closes #146.