### PR TITLE
Add Git Attributes for Yarn Lock File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /.yarn/** linguist-vendored
 /.yarn/releases/* binary
 /.pnp.* binary linguist-generated
+yarn.lock -diff linguist-generated


### PR DESCRIPTION
This pull request sets the Git attributes for the `yarn.lock` file to mark it as generated and disable diff for that file. It closes #171.