### PR TITLE
Remove Prettier Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .*
 !.eslint*
 !.git*
-!.prettier*
 
 coverage/
 dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-.yarn/
-dist/
-node_modules/
-
-.pnp.*
-package-lock.json


### PR DESCRIPTION
This pull request removes `.prettierignore` file from this project in favor of using `.gitignore` to ignore files to format.