### PR TITLE
Disable Source Map Generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Node16",
     "declaration": true,
     "outDir": "dist",
-    "sourceMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2022"],


### PR DESCRIPTION
This pull request modifies TypeScript from generating source map files. It closes #182.