### PR TITLE
Bump Copyright Year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Alfi Maulana
+Copyright (c) 2023-2024 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ page ?  rank ?  best city to travel
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
 
-Copyright © 2023 [Alfi Maulana](https://github.com/threeal)
+Copyright © 2023-2024 [Alfi Maulana](https://github.com/threeal)


### PR DESCRIPTION
This pull request simply bumps the copyright year in the `LICENSE` file and the license section of `README.md` file to 2024.