### PR TITLE
Use Prettier with Cache Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "format": "prettier --write .",
+    "format": "prettier --write --cache .",
     "lint": "eslint src",
     "prepack": "nx build",
     "sort": "sort-package-json",


### PR DESCRIPTION
This pull request resolves #245 by modifying the `format` script to call the `prettier` command with the `--cache` option enabled.