### PR TITLE
Use Yarn Install Action in Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,20 +23,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Update Yarn
-        run: yarn set version stable
-
-      - name: Cache deps
-        uses: actions/cache@v4.0.0
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install deps
-        run: yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Check format
         run: |


### PR DESCRIPTION
This pull request resolves #262 by modifying the `ci` workflow in this project to use the [Yarn Install Action](https://github.com/threeal/yarn-install-action/) for installing dependencies.