### PR TITLE
Separate Workflows for Build and Test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,19 +1,13 @@
-name: CI
+name: Build
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
-env:
-  NODE_OPTIONS: --experimental-vm-modules
 jobs:
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -23,11 +17,13 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install deps
+      - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 
-      - name: Build dist
+      - name: Create Package
         run: corepack yarn pack
 
-      - name: Run bin
-        run: corepack yarn google-rank --help
+      - name: Upload Package as Artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          path: package.tgz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,5 @@ jobs:
       - name: Build dist
         run: corepack yarn pack
 
-      - name: Test lib
-        run: corepack yarn test
-
       - name: Run bin
         run: corepack yarn google-rank --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,6 @@ jobs:
       - name: Install deps
         uses: threeal/yarn-install-action@v1.0.0
 
-      - name: Check format
-        run: |
-          corepack yarn format
-          git diff --exit-code HEAD
-
-      - name: Check lint
-        run: corepack yarn lint
-
       - name: Build dist
         run: corepack yarn pack
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Test
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test-package:
+    name: Test Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: latest
+
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@v1.0.0
+
+      - name: Test Package
+        run: corepack yarn test
+        env:
+          NODE_OPTIONS: --experimental-vm-modules

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,29 @@ on:
   push:
     branches: [main]
 jobs:
+  check-package:
+    name: Check Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: latest
+
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@v1.0.0
+
+      - name: Check Format
+        run: |
+          corepack yarn format
+          git diff --exit-code HEAD
+
+      - name: Check Lint
+        run: corepack yarn lint
+
   test-package:
     name: Test Package
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/google-rank?style=flat-square)](https://www.npmjs.com/package/google-rank)
 [![license](https://img.shields.io/github/license/threeal/google-rank?style=flat-square)](./LICENSE)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/google-rank/ci.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/google-rank/actions/workflows/ci.yaml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/google-rank/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/google-rank/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/google-rank/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/google-rank/actions/workflows/test.yaml)
 
 Google Rank is a tool designed to provide valuable insights into website visibility on [Google](https://www.google.com/) search results. By tracking and monitoring your website's ranking for specific keywords, you can optimize your online presence and effectively reach a wider audience.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/google-rank?style=flat-square)](https://www.npmjs.com/package/google-rank)
 [![license](https://img.shields.io/github/license/threeal/google-rank?style=flat-square)](./LICENSE)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/google-rank/ci.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/google-rank/actions/workflows/ci.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/google-rank/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/google-rank/actions/workflows/test.yaml)
 
 Google Rank is a tool designed to provide valuable insights into website visibility on [Google](https://www.google.com/) search results. By tracking and monitoring your website's ranking for specific keywords, you can optimize your online presence and effectively reach a wider audience.
 


### PR DESCRIPTION
This pull request resolves #174 by separating the `ci` workflow into `build` and `test` workflows.