### PR TITLE
Simplify ESLint Configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,12 +8,7 @@
   "overrides": [
     {
       "files": ["**/*.mts", "**/*.ts"],
-      "extends": ["plugin:@typescript-eslint/recommended"],
-      "parser": "@typescript-eslint/parser",
-      "parserOptions": {
-        "project": "tsconfig.eslint.json"
-      },
-      "plugins": ["@typescript-eslint"]
+      "extends": ["plugin:@typescript-eslint/recommended"]
     },
     {
       "files": ["**/*.test.*"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.mts", "**/*.ts"],
+      "files": ["**/*.?([cm])ts"],
       "extends": ["plugin:@typescript-eslint/recommended"]
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "root": true,
   "extends": ["eslint:recommended"],
-  "parserOptions": {
-    "ecmaVersion": 2022,
-    "sourceType": "module"
-  },
   "overrides": [
     {
       "files": ["**/*.?([cm])ts"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,12 +7,6 @@
       "extends": ["plugin:@typescript-eslint/recommended"]
     },
     {
-      "files": ["**/*.test.*"],
-      "env": {
-        "jest": true
-      }
-    },
-    {
       "files": ["package.json"],
       "plugins": ["json-files"],
       "rules": {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": []
-}


### PR DESCRIPTION
This pull request resolves #267 by introducing the following changes to the `.eslintrc.json` configuration file:
- Simplifying the configuration for TypeScript files by removing the `@typescript-eslint/parser` parser and the `@typescript-eslint` plugins configuration because they are already set when extending from the `plugin:@typescript-eslint/recommended`.
- Simplifying the glob pattern for TypeScript files to `**/*.?([cm])ts`.
- Removing the `parserOptions` and Jest environment because they're no longer used.
- Removing the `tsconfig.eslint.json` file.