### PR TITLE
Removes `NODE_OPTIONS` Environment When Running Test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,5 +45,3 @@ jobs:
 
       - name: Test Package
         run: corepack yarn test
-        env:
-          NODE_OPTIONS: --experimental-vm-modules


### PR DESCRIPTION
This pull request resolves #269 by removing the `NODE_OPTIONS` environment from the `test-package` job of the `test` workflow.