### PR TITLE
Audit TypeScript Configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "Node16",
+    "module": "node16",
     "declaration": true,
     "outDir": "dist",
-    "target": "ES2022",
+    "target": "es2022",
     "skipLibCheck": true
   },
   "include": ["src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "include": ["src"],
+  "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
     "strict": true,
@@ -7,7 +9,5 @@
     "outDir": "dist",
     "target": "es2022",
     "skipLibCheck": true
-  },
-  "include": ["src"],
-  "exclude": ["**/*.test.*"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "module": "Node16",
-    "moduleResolution": "Node16",
     "declaration": true,
     "outDir": "dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2022"],
     "target": "ES2022",
     "skipLibCheck": true
   },


### PR DESCRIPTION
This pull request resolves #271 by introducing the following changes to the `tsconfig.json` file:
- Removes the following unnecessary compiler options:
  - `moduleResolution`, already defaults to the same as `module` option.
  - `esModuleInterop`, already defaults to true if using `node16` or `nodenext`.
  - `forceConsistentCasingInFileNames`, already defaults to true.
  - `lib`, not required in this project.
- Adds a `exactOptionalPropertyTypes` compiler option that set to true.
- Adjust `module` and `target` compiler options to use lowercase values.
- Reorder position of the `include` and `exclude` options.