### PR TITLE
Audit ts-jest Configuration for ESM Support

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -12,7 +12,6 @@
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.mjs$": "$1.mts"
   },
-  "testMatch": ["**/*.test.ts"],
   "transform": {
     "^.+\\.m?ts$": ["ts-jest", { "useESM": true }]
   }

--- a/jest.config.json
+++ b/jest.config.json
@@ -8,10 +8,10 @@
       "statements": 100
     }
   },
-  "extensionsToTreatAsEsm": [".ts", ".mts"],
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.mjs$": "$1.mts"
   },
+  "preset": "ts-jest/presets/default-esm",
   "transform": {
     "^.+\\.m?ts$": ["ts-jest", { "useESM": true }]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node16",
     "declaration": true,
     "outDir": "dist",
+    "esModuleInterop": true,
     "target": "es2022",
     "skipLibCheck": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
     "outDir": "dist",
     "target": "es2022",


### PR DESCRIPTION
This pull request resolves #275 by introducing the following changes:
- Removes the `testMatch` option from the `jest.config.json` configuration file, effectively requiring the `moduleResolution` option to be specified in the `tsconfig.json` configuration file.
- Replaces the `extensionsToTreatAsEsm` option in the `jest.config.json` configuration file with the `preset` option.
- Enables the `esModuleInterop` option in the `tsconfig.json` configuration file.