### PR TITLE
Set `NODE_OPTIONS` for Running `test` Command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,5 +45,3 @@ jobs:
 
       - name: Test Package
         run: corepack yarn test
-        env:
-          NODE_OPTIONS: --experimental-vm-modules

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format": "prettier --write --cache .",
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
-    "test": "jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules yarn jest"
   },
   "dependencies": {
     "chalk": "^5.3.0",
@@ -44,6 +44,7 @@
     "@types/node": "^20.11.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "eslint-plugin-json-files": "^4.1.0",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,7 +1840,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.1"
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 10c0/f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2671,6 +2683,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^6.21.0"
     chalk: "npm:^5.3.0"
     commander: "npm:^12.0.0"
+    cross-env: "npm:^7.0.3"
     eslint: "npm:^8.56.0"
     eslint-plugin-json-files: "npm:^4.1.0"
     google-sr: "npm:^3.2.1"


### PR DESCRIPTION
This pull request resolves #277 by introducing the following changes:
- Adds [cross-env](https://www.npmjs.com/package/cross-env) to the development dependencies.
- Sets the `NODE_OPTIONS` environment variable with `--experimental-vm-modules` before executing the `jest` command in the `test` script.
- Removes the `NODE_OPTIONS` environment variable from the `test-package` job in the `test` workflow.