### PR TITLE
Utilize `.env.yarn` to Set `NODE_OPTIONS`

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.eslint*
 !.git*
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format": "prettier --write --cache .",
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules yarn jest"
+    "test": "jest"
   },
   "dependencies": {
     "chalk": "^5.3.0",
@@ -44,7 +44,6 @@
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
-    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,19 +1761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: "npm:^7.0.1"
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 10c0/f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2546,7 +2534,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.0.2"
     chalk: "npm:^5.3.0"
     commander: "npm:^12.0.0"
-    cross-env: "npm:^7.0.3"
     eslint: "npm:^8.56.0"
     google-sr: "npm:^3.2.1"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #290 by utilizing the `.env.yarn` file to set the `NODE_OPTIONS` environment variable. Additionally, it adjusts the `test` script accordingly and removes the [cross-env](https://www.npmjs.com/package/cross-env) package from the dependencies.