### PR TITLE
Utilize Setup Yarn Berry Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Create Package
-        run: corepack yarn pack
+        run: yarn pack
 
       - name: Upload Package as Artifact
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
+        with:
+          version: stable
 
       - name: Create Package
         run: yarn pack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@v2.0.0
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Create Package
         run: corepack yarn pack

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
+        with:
+          version: stable
 
       - name: Check Format
         run: |
@@ -42,6 +44,8 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
+        with:
+          version: stable
 
       - name: Test Package
         run: yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@v2.0.0
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Check Format
         run: |
@@ -40,8 +40,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Install Dependencies
-        uses: threeal/yarn-install-action@v2.0.0
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Test Package
         run: corepack yarn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Check Format
         run: |
-          corepack yarn format
+          yarn format
           git diff --exit-code HEAD
 
       - name: Check Lint
-        run: corepack yarn lint
+        run: yarn lint
 
   test-package:
     name: Test Package
@@ -44,4 +44,4 @@ jobs:
         uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Test Package
-        run: corepack yarn test
+        run: yarn test


### PR DESCRIPTION
This pull request resolves #294 by introducing the following changes in the workflows:
- Changed the "Install Dependencies" step to "Setup Yarn" step, utilizing the [Setup Yarn Berry](https://github.com/threeal/setup-yarn-action/) action to set up Yarn to the stable version while also installing the project dependencies.
- Replaced the call to the `corepack yarn` command with just the `yarn` command.