### PR TITLE
Bump Yarn to Version 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
   },
-  "packageManager": "yarn@4.1.0"
+  "packageManager": "yarn@4.1.1"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.1.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.1.1).