### PR TITLE
Bump Yarn to version 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^7.17.0"
   },
-  "packageManager": "yarn@4.3.1"
+  "packageManager": "yarn@4.4.0"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.4.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.4.0).