### PR TITLE
Remove Run Function in Binary Script

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -8,30 +8,24 @@ import { getWebsiteRank, WebsiteRank } from "./rank.js";
 
 type RankPromise = Promise<WebsiteRank | undefined>;
 
-async function run() {
-  const parser = new ArgumentsParser();
-  const args = await parser.parse();
+const parser = new ArgumentsParser();
+const args = await parser.parse();
 
-  const rankByKeywords: [string, RankPromise][] = [];
-  for (const keyword of args.keywords) {
-    const prom = getWebsiteRank(args.website, keyword, {
-      maxPage: args.maxPage,
-    });
-    rankByKeywords.push([keyword, prom]);
-  }
-
-  process.stdout.write(
-    `Ranks for ${chalk.blueBright(args.website)} website:\n`,
-  );
-
-  const loading = ora("Getting ranks...");
-  loading.start();
-  for (const [keyword, prom] of rankByKeywords) {
-    loading.text = `Getting ranks of ${chalk.blueBright(keyword)} keyword...`;
-    const str = formatKeywordRank(keyword, await prom);
-    process.stdout.write(`\r\x1b[K${str}\n`);
-  }
-  loading.stop();
+const rankByKeywords: [string, RankPromise][] = [];
+for (const keyword of args.keywords) {
+  const prom = getWebsiteRank(args.website, keyword, {
+    maxPage: args.maxPage,
+  });
+  rankByKeywords.push([keyword, prom]);
 }
 
-run();
+process.stdout.write(`Ranks for ${chalk.blueBright(args.website)} website:\n`);
+
+const loading = ora("Getting ranks...");
+loading.start();
+for (const [keyword, prom] of rankByKeywords) {
+  loading.text = `Getting ranks of ${chalk.blueBright(keyword)} keyword...`;
+  const str = formatKeywordRank(keyword, await prom);
+  process.stdout.write(`\r\x1b[K${str}\n`);
+}
+loading.stop();


### PR DESCRIPTION
This pull request resolves #425 by removing the `run` function in favor of directly calling the content of the `run` function at the top level.