### PR TITLE
Extend TypeScript Configuration from Node.js Base Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@tsconfig/node23": "^23.0.0",
     "@types/node": "^22.13.10",
     "@vitest/coverage-v8": "^3.0.5",
     "eslint": "^9.22.0",
@@ -47,5 +48,10 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
     "vitest": "^3.0.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^9.22.0
         version: 9.22.0
+      '@tsconfig/node23':
+        specifier: ^23.0.0
+        version: 23.0.0
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -423,6 +426,9 @@ packages:
     resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
     cpu: [x64]
     os: [win32]
+
+  '@tsconfig/node23@23.0.0':
+    resolution: {integrity: sha512-a2qO9QOEWnomKbFFE3XlOJ5za6Sc+XduxQkFpah42enbTPFPaW0QzKw616KDNfmMLPhXMwCw4EHVjcKaFOj/OA==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1634,6 +1640,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     optional: true
+
+  '@tsconfig/node23@23.0.0': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,9 @@
 {
+  "extends": "@tsconfig/node23",
   "include": ["src"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "strict": true,
-    "module": "node16",
-    "moduleResolution": "node16",
     "declaration": true,
-    "outDir": "dist",
-    "target": "es2022",
-    "skipLibCheck": true
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
This pull request resolves #631 by extending `tsconfig.json` from [@tsconfig/node23](https://www.npmjs.com/package/@tsconfig/node23).