### PR TITLE
Remove Upload Package Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,9 +32,3 @@ jobs:
 
       - name: Package Libarry
         run: pnpm pack --out package.tgz
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: package
-          path: package.tgz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,4 +31,4 @@ jobs:
         run: pnpm test
 
       - name: Package Libarry
-        run: pnpm pack --out package.tgz
+        run: pnpm pack

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 dist/
 node_modules/
 
-package.tgz
+*.tgz


### PR DESCRIPTION
This pull request resolves #640 by removing the "Upload Package" step from the `build` workflow. Additionally, this change updates the project to use the default output name for packaging the library.