### PR TITLE
Add Start Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "prepack": "tsc",
+    "start": "vite-node src/bin.ts",
     "test": "vitest run"
   },
   "dependencies": {
@@ -46,6 +47,7 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.27.0",
+    "vite-node": "^3.0.9",
     "vitest": "^3.0.5"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       typescript-eslint:
         specifier: ^8.27.0
         version: 8.27.0(eslint@9.22.0)(typescript@5.8.2)
+      vite-node:
+        specifier: ^3.0.9
+        version: 3.0.9(@types/node@22.13.10)
       vitest:
         specifier: ^3.0.5
         version: 3.0.5(@types/node@22.13.10)
@@ -1342,6 +1345,11 @@ packages:
 
   vite-node@3.0.5:
     resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite-node@3.0.9:
+    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2673,6 +2681,27 @@ snapshots:
       punycode: 2.3.1
 
   vite-node@3.0.5(@types/node@22.13.10):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.1.0(@types/node@22.13.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.0.9(@types/node@22.13.10):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0


### PR DESCRIPTION
This pull request resolves #646 by adding a `start` script to execute the `src/bin.ts` file directly using [vite-node](https://www.npmjs.com/package/vite-node).