### PR TITLE
Bump Node to Version 24.1.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.0.1
+use-node-version=24.1.0


### PR DESCRIPTION
This pull request bumps the Node version specified in the `.npmrc` file to version [24.1.0](https://github.com/nodejs/node/releases/tag/v24.1.0).