### PR TITLE
Add Step to Install Dependencies in Pre-commit Hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,13 @@
 pre-commit:
   piped: true
   jobs:
+    - name: install dependencies
+      run: pnpm install
+      glob:
+        - package.json
+        - pnpm-lock.yaml
+        - pnpm-workspace.yaml
+
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}
 


### PR DESCRIPTION
This pull request resolves #719 by adding a step to instal dependencies in the pre-commit hook via the Lefthook configuration.