### PR TITLE
Use jiti to Execute TypeScript File

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "prepack": "tsc -p tsconfig.build.json",
-    "start": "vite-node src/bin.ts",
+    "start": "jiti src/bin.ts",
     "test": "vitest run"
   },
   "dependencies": {
@@ -48,7 +48,6 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.1",
-    "vite-node": "^3.2.3",
     "vitest": "^3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       typescript-eslint:
         specifier: ^8.34.1
         version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
-      vite-node:
-        specifier: ^3.2.3
-        version: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)
       vitest:
         specifier: ^3.1.4
         version: 3.1.4(@types/node@22.15.30)(jiti@2.4.2)
@@ -1390,11 +1387,6 @@ packages:
 
   vite-node@3.1.4:
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
-  vite-node@3.2.3:
-    resolution: {integrity: sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2763,27 +2755,6 @@ snapshots:
       punycode: 2.3.1
 
   vite-node@3.1.4(@types/node@22.15.30)(jiti@2.4.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-node@3.2.3(@types/node@22.15.30)(jiti@2.4.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1


### PR DESCRIPTION
This pull request resolves #743 by utilizing [jiti](https://www.npmjs.com/package/jiti) to execute TypeScript file, replacing [vite-node](https://www.npmjs.com/package/vite-node).