### PR TITLE
Bump pnpm to version 11.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.12.0"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [11.12.0](https://github.com/pnpm/pnpm/releases/tag/v11.12.0).